### PR TITLE
Fix broken links in the main documentation

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "npm -C ../ run build:es -- -t es6 && gatsby build",
+    "build": "npm -C ../ run build:es -- -t es6 && gatsby build --prefix-paths",
     "deploy": "gh-pages -d public",
-    "start": "npm -C ../ run build:es -- -t es6 && gatsby develop"
+    "start": "npm -C ../ run build:es -- -t es6 && gatsby develop --prefix-paths"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Currently, the links in the main documentation (https://lkay.github.io/react-transition-replace/) are broken. `TransitionReplace` link redirects to `https://lkay.github.io/transition-replace` instead of `https://lkay.github.io/react-transition-replace/transition-replace`.

This PR adds `--prefix-paths` option to gatsby commands in CircleCI configuration to make Gatsby generates link properly.